### PR TITLE
Attendance Modal and Table Patches

### DIFF
--- a/apps/admin/src/components/AttendanceTable.tsx
+++ b/apps/admin/src/components/AttendanceTable.tsx
@@ -423,7 +423,10 @@ const AttendanceTable: React.FC<AttendanceTableProps> = ({
                     if (selectedMeeting) handleStaffSelect(staffMember);
                   }}
                   cursor="pointer"
-                  _hover={{ bgColor: "#ddd" }}
+                  _hover={{
+                    bgColor: "#ddd",
+                    _dark: { bgColor: "#2E3749" }
+                  }}
                 >
                   <Td>{staffMember.name}</Td>
                   <Td>

--- a/apps/admin/src/components/AttendanceView.tsx
+++ b/apps/admin/src/components/AttendanceView.tsx
@@ -239,6 +239,9 @@ function AttendanceView({
         borderRadius={"10px"}
         display="flex"
       >
+        {attendanceData.length === 0 && (
+          <Text mt={2}>No attendance data available</Text>
+        )}
         <Box width={"170px"} minWidth={"170px"} pt={"28px"}>
           {committeeTypes.map((committeeType, index) => (
             <Box

--- a/apps/admin/src/components/useAttendanceViewHook.ts
+++ b/apps/admin/src/components/useAttendanceViewHook.ts
@@ -60,8 +60,8 @@ export const useAttendanceViewHook = (attendanceData: StaffAttendance[]) => {
 
     // Get the range of dates in the attendance data
     const dates = attendanceData.map((item) => moment(item.meetingDate));
-    const startDate = moment.min(dates);
-    const endDate = moment.max(dates);
+    const startDate = moment.min(dates).clone();
+    const endDate = moment.max(dates).clone();
 
     // If there are less than 8 weeks of data, make endDate 8 weeks after startDate
     const weeksDifference = endDate.diff(startDate, "weeks");


### PR DESCRIPTION
- Fixed one meeting case for the attendance modal view:

![Screenshot 2025-04-30 at 3 37 11 PM](https://github.com/user-attachments/assets/8fc53703-a7d3-48d4-87bf-ea31c2cc4698)

If there was only one meeting, then `startDate` and `endDate` referred to the same date. So when 8 weeks were added to `endDate`, `startDate` referred to the same value, resulting in startDate and endDate showing the non-existent meetings 8 weeks after the one that occurred.

I fixed this by calling `clone()` after `moment.min(...)` and `moment.max(...)`.


- Added an empty state if no meetings have occured:

![Screenshot 2025-04-30 at 3 37 04 PM](https://github.com/user-attachments/assets/8437d798-9474-4d9c-9d50-e5a1a8d55f70)


- Improved dark mode table hover color:

![image](https://github.com/user-attachments/assets/e43e62fb-bbbc-49e2-9f64-67e700f5ab1d)

(Light mode is still the same):

![Screenshot 2025-04-30 at 3 39 31 PM](https://github.com/user-attachments/assets/228337d3-a04c-49af-8cc0-24057de58974)