### PR TITLE
Fix auth regression

### DIFF
--- a/apps/admin/src/routes/ProtectedRoute.tsx
+++ b/apps/admin/src/routes/ProtectedRoute.tsx
@@ -6,16 +6,9 @@ async function verifyAuth() {
   const jwt = localStorage.getItem("jwt");
 
   const currentPath = window.location.pathname + window.location.search;
-  if (!jwt && !localStorage.getItem("originalDestination")) {
-    if (
-      currentPath !== "/" &&
-      currentPath !== "/auth" &&
-      currentPath !== "/auth/"
-    ) {
-      localStorage.setItem("originalDestination", currentPath);
-    } else {
-      localStorage.setItem("originalDestination", "/home/");
-    }
+  if (!jwt) {
+    localStorage.setItem("originalDestination", currentPath);
+    window.location.href = "/auth";
   }
 
   const response = await api.get("/auth/info");

--- a/shared/src/api/axios.ts
+++ b/shared/src/api/axios.ts
@@ -29,7 +29,8 @@ function createApi(baseURL: string): TypedAxiosInstance {
         window.location.href = "/auth";
       }
 
-      return error;
+      // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
+      return Promise.reject(error);
     }
   );
 


### PR DESCRIPTION
"/" and "/auth" are not protected routes so the if condition is never false
the regression was caused due to new error handling navigating the user to the "/unauthorized" route