### PR TITLE
Fix navbar overflow bug

### DIFF
--- a/apps/site/src/components/Navbar.tsx
+++ b/apps/site/src/components/Navbar.tsx
@@ -167,7 +167,7 @@ const Navbar: React.FC<NavbarProps> = ({ isFlush }) => {
           py={{ base: "12px", xl: 3 }}
           gap={{ base: 8, xl: 32 }}
           px={{ base: 1, xl: 2 }}
-          overflow="scroll"
+          overflow={{ base: "scroll", xl: "hidden" }}
           maxH="100vh"
           flexDir={{ base: "column", xl: "row" }}
           justifyContent={{ base: "start", xl: "space-between" }}


### PR DESCRIPTION
Before fix, on desktop:

<img width="1177" height="126" alt="Screenshot 2025-08-23 at 5 18 56 PM" src="https://github.com/user-attachments/assets/e71a18ed-fcf2-4c2c-9cef-c8dae948f217" />

After fix:

<img width="1117" height="112" alt="Screenshot 2025-08-23 at 5 18 41 PM" src="https://github.com/user-attachments/assets/e1a735a6-5286-4892-980d-5deadf5fdb0a" />
