### PR TITLE
Updated stats page

### DIFF
--- a/apps/admin/src/routes/pages/Stats.tsx
+++ b/apps/admin/src/routes/pages/Stats.tsx
@@ -1,10 +1,10 @@
 import {
+  Text,
   Box,
   StatGroup,
   StatLabel,
   Stat,
   StatNumber,
-  StatHelpText,
   Card,
   Heading,
   NumberInput,
@@ -14,7 +14,11 @@ import {
   NumberDecrementStepper,
   CardHeader,
   Flex,
-  HStack
+  HStack,
+  Select,
+  StackDivider,
+  Stack,
+  useBreakpointValue
 } from "@chakra-ui/react";
 
 import { Bar } from "react-chartjs-2";
@@ -30,44 +34,61 @@ import { useMirrorStyles } from "@/styles/Mirror";
 import { useOutletContext } from "react-router-dom";
 import { MainContext } from "../Main";
 
+const eventTags = [
+  "Career Readiness",
+  "AI",
+  "Research",
+  "Interactive Events",
+  "HCI",
+  "Ethics",
+  "Art/Media",
+  "Autonomous Vehicles",
+  "Networking",
+  "Company Talk",
+  "Cybersecurity"
+];
+
 function Stats() {
   const { authorized } = useOutletContext<MainContext>();
 
-  const [numEvents, setNumEvents] = useState(0);
-  const [price, setPrice] = useState(0);
+  const [minNumEvents, setMinNumEvents] = useState(0);
+  const [eventId, setEventId] = useState("");
+  const [tagName, setTagName] = useState<string>("");
 
   const mirrorStyles = useMirrorStyles(true);
-  const { data: pastAttendanceData, isLoading: pastAttendanceLoading } =
-    usePolling(path("/stats/attendance/:n", { n: numEvents }), authorized);
-  const { data: eligiblePrize, isLoading: eligiblePrizeLoading } = usePolling(
-    path("/stats/merch-item/:price", { price }),
+  // const { data: pastAttendanceData, isLoading: pastAttendanceLoading } =
+  //   usePolling(path("/stats/attendance/:n", { n: numEvents }), authorized);
+  const { data: events, isLoading: eventsLoading } = usePolling(
+    "/events",
+    authorized
+  );
+  const { data: eventAttendanceData, isLoading: eventAttendanceLoading } =
+    usePolling(
+      path("/stats/event/:EVENT_ID/attendance", { EVENT_ID: eventId }),
+      authorized
+    );
+  const { data: numAttendedEventsData, isLoading: numAttendedEventsLoading } =
+    usePolling(
+      path("/stats/attended-at-least/:N", { N: minNumEvents }),
+      authorized
+    );
+  const { data: tagInterestData, isLoading: tagInterestLoading } = usePolling(
+    "/stats/tag-counts",
+    authorized
+  );
+  const { data: tierCountsData, isLoading: tierCountsLoading } = usePolling(
+    "/stats/tier-counts",
+    authorized
+  );
+  const { data: prizesGivenData, isLoading: prizesGivenLoading } = usePolling(
+    "/stats/merch-redemption-counts",
     authorized
   );
   const { data: dietaryRestrictions, isLoading: dietaryRestrictionsLoading } =
     usePolling("/stats/dietary-restrictions", authorized);
 
-  const pastAttendance = useMemo(() => {
-    if (!pastAttendanceData) {
-      return 0;
-    }
-
-    let sum = 0;
-    for (
-      let i = 0;
-      i < Math.min(numEvents, pastAttendanceData.attendanceCounts.length);
-      i++
-    ) {
-      if (typeof pastAttendanceData.attendanceCounts[i] === "number") {
-        sum += pastAttendanceData.attendanceCounts[i];
-      }
-    }
-
-    return sum;
-  }, [numEvents, pastAttendanceData]);
-
   const sortedAllergyCounts = useMemo(() => {
     if (!dietaryRestrictions) return dietaryRestrictions;
-    console.log(Object.entries(dietaryRestrictions?.allergyCounts).sort());
     return Object.entries(dietaryRestrictions?.allergyCounts).sort();
   }, [dietaryRestrictions]);
 
@@ -76,13 +97,20 @@ function Stats() {
     return Object.entries(dietaryRestrictions?.dietaryRestrictionCounts).sort();
   }, [dietaryRestrictions]);
 
+  const responsiveStackDivider = useBreakpointValue({
+    base: undefined, // no divider on small screens
+    sm: <StackDivider />,
+    md: undefined,
+    lg: <StackDivider />
+  });
+
   return (
     <>
       <Flex justifyContent="center" alignItems="center">
         <Heading size="lg">Stats</Heading>
       </Flex>
       <br />
-      <StatGroup display="flex" flexDir="column" alignItems="center" gap={8}>
+      <StatGroup display="flex" flexDir="column" alignItems="center" gap={4}>
         <HStack w="100%" gap={4}>
           <StatCard
             label="Number Checked-In"
@@ -91,63 +119,226 @@ function Stats() {
             transformer={(data) => data.count}
           />
           <StatCard
-            label="Priority Attendees"
-            endpoint="/stats/priority-attendee"
+            label="Total Registrations"
+            endpoint="/stats/registrations"
             enabled={authorized}
             transformer={(data) => data.count}
           />
         </HStack>
         <HStack w="100%" gap={4}>
           <Stat sx={mirrorStyles}>
-            <StatLabel display="flex" alignItems="center">
-              Past Event Attendance:
-              <NumberInput
-                size="sm"
-                maxW="100px"
-                ml="4"
-                value={numEvents}
-                onChange={(_, value) => setNumEvents(value)}
-                min={0}
-              >
-                <NumberInputField />
-                <NumberInputStepper>
-                  <NumberIncrementStepper />
-                  <NumberDecrementStepper />
-                </NumberInputStepper>
-              </NumberInput>
+            <StatLabel
+              display="flex"
+              alignItems="center"
+              justifyContent="center"
+            >
+              People eligible for prizes
             </StatLabel>
-            <StatNumber>
-              {pastAttendanceLoading ? "—" : pastAttendance}
-            </StatNumber>
-            <StatHelpText>
-              {/* Add any additional info or icons here */}
-            </StatHelpText>
+            <StatLabel>
+              {tierCountsLoading ? (
+                "-"
+              ) : (
+                <Stack
+                  textAlign="center"
+                  justifyContent="center"
+                  spacing={{ base: 0, sm: 1, md: 0, lg: 3 }}
+                  direction={{
+                    base: "column",
+                    sm: "row",
+                    md: "column",
+                    lg: "row"
+                  }}
+                  divider={responsiveStackDivider}
+                  lineHeight="1.5rem"
+                  mt={{ base: 0, sm: 4, md: 0, lg: 4 }}
+                >
+                  <Text>
+                    shirts:{" "}
+                    {(tierCountsData?.TIER1 ?? 0) +
+                      (tierCountsData?.TIER2 ?? 0) +
+                      (tierCountsData?.TIER3 ?? 0) +
+                      (tierCountsData?.TIER4 ?? 0)}
+                  </Text>
+                  <Text>
+                    key chains:{" "}
+                    {(tierCountsData?.TIER2 ?? 0) +
+                      (tierCountsData?.TIER3 ?? 0) +
+                      (tierCountsData?.TIER4 ?? 0)}
+                  </Text>
+                  <Text>
+                    squishies:{" "}
+                    {(tierCountsData?.TIER3 ?? 0) +
+                      (tierCountsData?.TIER4 ?? 0)}
+                  </Text>
+                  <Text>beanies: {tierCountsData?.TIER4 ?? 0}</Text>
+                </Stack>
+              )}
+            </StatLabel>
           </Stat>
           <Stat sx={mirrorStyles}>
-            <StatLabel display="flex" alignItems="center">
-              Eligible for Prizes $
-              <NumberInput
-                size="sm"
-                maxW="100px"
-                ml="4"
-                value={price}
-                onChange={(_, value) => setPrice(value)}
-                min={0}
-              >
-                <NumberInputField />
-                <NumberInputStepper>
-                  <NumberIncrementStepper />
-                  <NumberDecrementStepper />
-                </NumberInputStepper>
-              </NumberInput>
+            <StatLabel
+              display="flex"
+              alignItems="center"
+              justifyContent="center"
+            >
+              Physical prizes given out
             </StatLabel>
-            <StatNumber>
-              {eligiblePrizeLoading ? "—" : eligiblePrize?.count}
-            </StatNumber>
-            <StatHelpText>
-              {/* Add any additional info or icons here */}
-            </StatHelpText>
+            <StatLabel>
+              {prizesGivenLoading ? (
+                "-"
+              ) : (
+                <Stack
+                  textAlign="center"
+                  justifyContent="center"
+                  spacing={{ base: 0, sm: 1, md: 0, lg: 3 }}
+                  direction={{
+                    base: "column",
+                    sm: "row",
+                    md: "column",
+                    lg: "row"
+                  }}
+                  divider={responsiveStackDivider}
+                  lineHeight="1.5rem"
+                  mt={{ base: 0, sm: 4, md: 0, lg: 4 }}
+                >
+                  <Text>shirts: {prizesGivenData?.TIER1 ?? 0}</Text>
+                  <Text>key chains: {prizesGivenData?.TIER2 ?? 0}</Text>
+                  <Text>squishies: {prizesGivenData?.TIER3 ?? 0}</Text>
+                  <Text>beanies: {prizesGivenData?.TIER4 ?? 0}</Text>
+                </Stack>
+              )}
+            </StatLabel>
           </Stat>
+        </HStack>
+        <HStack w="100%" gap={4}>
+          <Stat sx={mirrorStyles}>
+            <StatLabel
+              display="flex"
+              alignItems="center"
+              justifyContent="center"
+              gap={2}
+              flexDirection={{
+                base: "column",
+                sm: "row",
+                md: "column",
+                lg: "row"
+              }}
+            >
+              Attendance for
+              <Select
+                flex={1}
+                maxW="fit-content"
+                placeholder="event..."
+                value={eventId}
+                onChange={(event) => setEventId(event.target.value)}
+              >
+                {eventsLoading ? (
+                  <></>
+                ) : (
+                  events?.map((event) => (
+                    <option key={event.eventId} value={event.eventId}>
+                      {event.name}
+                    </option>
+                  ))
+                )}
+              </Select>
+            </StatLabel>
+            <StatNumber mt={1}>
+              {eventAttendanceLoading ? (
+                "—"
+              ) : (
+                <Text>{eventAttendanceData?.attendanceCount ?? 0}</Text>
+              )}
+            </StatNumber>
+          </Stat>
+          <Stat sx={mirrorStyles}>
+            <StatLabel
+              display="flex"
+              alignItems="center"
+              justifyContent="center"
+              gap={2}
+              flexDirection={{
+                base: "column",
+                sm: "row",
+                md: "column",
+                lg: "row"
+              }}
+            >
+              <Text>Interest in</Text>
+              <Select
+                flex={1}
+                maxW="fit-content"
+                placeholder="tag..."
+                onChange={(event) => setTagName(event.target.value)}
+              >
+                {eventTags?.map((tag) => (
+                  <option key={tag} value={tag}>
+                    {tag}
+                  </option>
+                ))}
+              </Select>
+              <Text
+                display={{ base: "none", sm: "block", md: "none", lg: "block" }}
+              >
+                events:
+              </Text>
+            </StatLabel>
+            <StatNumber mt={1}>
+              {tagInterestLoading ? (
+                "—"
+              ) : (
+                <Text>
+                  {tagInterestData ? (tagInterestData[tagName] ?? 0) : "x"}
+                </Text>
+              )}
+            </StatNumber>
+          </Stat>
+        </HStack>
+        <HStack w="100%" gap={4}>
+          <Stat sx={mirrorStyles}>
+            <StatLabel
+              display="flex"
+              alignItems="center"
+              justifyContent="center"
+              gap={2}
+              flexDirection={{
+                base: "column",
+                sm: "row",
+                md: "column",
+                lg: "row"
+              }}
+            >
+              <Text>People who have attended</Text>
+              <Flex gap={2}>
+                <NumberInput
+                  size="sm"
+                  maxW="100px"
+                  value={minNumEvents}
+                  onChange={(_, value) => setMinNumEvents(value)}
+                  min={0}
+                >
+                  <NumberInputField />
+                  <NumberInputStepper>
+                    <NumberIncrementStepper />
+                    <NumberDecrementStepper />
+                  </NumberInputStepper>
+                </NumberInput>
+                <Text>events:</Text>
+              </Flex>
+            </StatLabel>
+
+            <StatNumber>
+              {numAttendedEventsLoading
+                ? "—"
+                : (numAttendedEventsData?.count ?? 0)}
+            </StatNumber>
+          </Stat>
+          <StatCard
+            label="Priority Attendees"
+            endpoint="/stats/priority-attendee"
+            enabled={authorized}
+            transformer={(data) => data.count}
+          />
         </HStack>
         <Card sx={mirrorStyles} w="90%">
           <CardHeader>

--- a/shared/src/api/types.ts
+++ b/shared/src/api/types.ts
@@ -481,12 +481,12 @@ export interface APIRoutes {
       response: { attendanceCounts: number[] };
     };
   };
-  "/stats/check-in": {
+  "/stats/attended-at-least/:N": {
     GET: {
       response: { count: number };
     };
   };
-  "/stats/priority-attendee": {
+  "/stats/check-in": {
     GET: {
       response: { count: number };
     };
@@ -496,9 +496,39 @@ export interface APIRoutes {
       response: DietaryRestrictionStats;
     };
   };
+  "/stats/event/:EVENT_ID/attendance": {
+    GET: {
+      response: { attendanceCount: number };
+    };
+  };
   "/stats/merch-item/:price": {
     GET: {
       response: { count: number };
+    };
+  };
+  "/stats/priority-attendee": {
+    GET: {
+      response: { count: number };
+    };
+  };
+  "/stats/merch-redemption-counts": {
+    GET: {
+      response: Record<string, number>;
+    };
+  };
+  "/stats/registrations": {
+    GET: {
+      response: { count: number };
+    };
+  };
+  "/stats/tag-counts": {
+    GET: {
+      response: Record<string, number>;
+    };
+  };
+  "/stats/tier-counts": {
+    GET: {
+      response: Record<string, number>;
     };
   };
   "/shifts": {


### PR DESCRIPTION
Added stats/stat cards and connected to Ritam's new API endpoints: 
- Total registrations
- Number of people who unlocked each prize
- Number of people who redeemed each prize
- Attendance by event
- People who marked each tag
- People who have attended n events

Removed stats/cards:
- People who attended the n-past event
- People at n points

Talked about it with shole :)