### PR TITLE
Optimize dashboard for Siebel TVs, DayEvent refactor

### DIFF
--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -8,12 +8,12 @@ import {
 } from "@chakra-ui/react";
 import "@fontsource/nunito";
 import "@fontsource/roboto-slab";
+import { useTime } from "@rp/shared";
 import Events from "./components/Events";
 import Leaderboard from "./components/Leaderboard";
 import { RegisterNow } from "./components/RegisterNow";
 import { Sponsors } from "./components/Sponsors";
 import Title from "./components/Title";
-import { useTime } from "@rp/shared";
 import useTimeSyncedReload from "./hooks/TimeSynchedReload";
 
 const config: ThemeConfig = {
@@ -47,29 +47,24 @@ function App() {
           alignItems={"center"}
           width={"100%"}
           minH="100vh"
-          padding={"2rem"}
-          paddingTop="0.5rem"
+          padding={"2vh"}
+          paddingTop="0.5vh"
           zIndex={2}
         >
           <Title />
-          <Flex width={"100%"} mt={4} flexGrow={1}>
-            <Flex
-              width={"50%"}
-              flexGrow={"1"}
-              marginRight={"5rem"}
-              alignItems={"end"}
-            >
+          <Flex width={"100%"} mt={"0"} flexGrow={1}>
+            <Flex width={"50%"} marginRight={"1vh"} alignItems={"end"}>
               <Text
                 position={"absolute"}
-                top={"0.5rem"}
+                top={"1.5vh"}
                 left={"25%"}
-                fontSize={"3xl"}
+                fontSize={"2.5vh"}
                 fontWeight="bold"
                 color="white"
                 fontFamily="ProRacingSlant"
                 textAlign="center"
                 transform={"translateX(-50%)"}
-                paddingX={"1rem"}
+                paddingX={"2vh"}
                 borderRadius="1rem"
                 bgColor={"rgba(0,0,0,0.2)"}
               >
@@ -79,10 +74,9 @@ function App() {
             </Flex>
             <Flex
               width={"50%"}
-              marginLeft={"5rem"}
               alignItems={"right"}
               flexDir={"column"}
-              gap={4}
+              gap={"1.5vh"}
             >
               <Events date={date} />
               <Sponsors />

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -56,7 +56,7 @@ function App() {
             <Flex width={"50%"} marginRight={"1vh"} alignItems={"end"}>
               <Text
                 position={"absolute"}
-                top={"1.5vh"}
+                top={"0.5vh"}
                 left={"25%"}
                 fontSize={"2.5vh"}
                 fontWeight="bold"

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -64,7 +64,7 @@ function App() {
                 fontFamily="ProRacingSlant"
                 textAlign="center"
                 transform={"translateX(-50%)"}
-                paddingX={"2vh"}
+                paddingX={"1.25vh"}
                 borderRadius="1rem"
                 bgColor={"rgba(0,0,0,0.2)"}
               >

--- a/apps/dashboard/src/components/Events.tsx
+++ b/apps/dashboard/src/components/Events.tsx
@@ -1,18 +1,7 @@
-import {
-  Box,
-  Flex,
-  Grid,
-  Icon,
-  Text,
-  Tooltip,
-  useToast
-} from "@chakra-ui/react";
-import { api, Event } from "@rp/shared";
+import { Box, Flex, Text, useToast } from "@chakra-ui/react";
+import { api, Event, DayEvent } from "@rp/shared";
 import moment from "moment";
 import { useEffect, useState } from "react";
-
-import { CIRCLE_COLORS } from "@/constants/colors";
-import { EVENT_ICONS } from "@/constants/event-icons";
 
 type EventSelected = Event & {
   selected?: boolean;
@@ -105,46 +94,44 @@ export default function Events({ date }: EventsProps) {
     <Box float={"right"} width={"100%"}>
       <Text
         w="100%"
-        fontSize={"3xl"}
+        fontSize={"2.5vh"}
         fontWeight="bold"
         color="white"
         fontFamily="ProRacingSlant"
         textAlign="center"
-        mb={3}
+        mb={"1.5vh"}
       >
         Events
       </Text>
       <Flex
-        marginTop={"0.5rem"}
+        marginTop={"0.5vh"}
         justifyContent="center"
-        flexDirection={{ md: "column-reverse", lg: "row" }}
+        flexDirection="row"
         mx="auto"
-        gap={0}
         position="relative" /* ensure content sits above accent */
         zIndex={1}
       >
         <Box flex={1} h="100%" py={0}>
           <Box
-            overflowY={{ md: "auto" }}
             shadow={"md"}
             boxShadow="md"
             bgColor={"rgba(0,0,0,0.2)"}
-            borderRadius={"1rem"}
-            py={3}
+            borderRadius={"1vh"}
+            py={"1vh"}
           >
             <Box
               overflowY="auto"
               height={"100%"}
-              gap={3}
+              gap={"1vh"}
               display="flex"
               flexDirection={"column"}
-              px={2}
+              px={"1vh"}
             >
               {events.length === 0 && (
                 <Text
                   fontSize="xl"
                   color="gray.500"
-                  fontFamily="Racing Sans One"
+                  fontFamily="Magistral"
                   textAlign="center"
                 >
                   No events scheduled yet.
@@ -157,6 +144,7 @@ export default function Events({ date }: EventsProps) {
                     number={index + 1}
                     event={event}
                     selected={event.selected}
+                    variant="dashboard"
                   />
                 ))}
             </Box>
@@ -167,150 +155,6 @@ export default function Events({ date }: EventsProps) {
   );
 }
 
-function DayEvent({
-  number,
-  event,
-  selected
-}: {
-  number: number;
-  event: Event;
-  selected?: boolean;
-}) {
-  return (
-    <Grid
-      px={{
-        base: 3,
-        md: 5
-      }}
-      pt={number === 0 ? 6 : 0}
-      py={3}
-      templateColumns={{
-        base: "12px 8px 1fr 40px",
-        md: "20px 10px 1fr 40px"
-      }}
-      alignItems="right"
-      gap={{
-        base: 2,
-        md: 3
-      }}
-      backgroundColor={selected ? "rgba(255,255,255,0.2)" : undefined}
-      borderRadius={selected ? "0.5rem" : undefined}
-      _first={{
-        paddingTop: "calc(3px + 0.5rem)",
-        borderTopRadius: "0.5rem"
-      }}
-      _last={{
-        paddingBottom: "calc(3px + 0.5rem)",
-        borderBottomRadius: "0.5rem"
-      }}
-      transition={"all 0.2s"}
-      sx={{
-        backdropFilter: "blur(3px)",
-        WebkitBackdropFilter: "blur(3px)" // for Safari
-        // optional: add a slight border and drop shadow
-      }}
-    >
-      <Box
-        display="flex"
-        justifyContent={"center"}
-        alignItems={"center"}
-        w={"10px"}
-        borderRadius="sm"
-      >
-        <Text
-          fontSize={"xl"}
-          color="gray.200"
-          fontWeight="thin"
-          textAlign="center"
-          fontFamily="ProRacingSlant"
-          mb={"2px"}
-          mt={"4px"}
-        >
-          {number}
-        </Text>
-      </Box>
-
-      <Box
-        display="flex"
-        justifyContent={"center"}
-        alignItems={"center"}
-        w={{
-          base: "5px",
-          md: "7px"
-        }}
-        h="100%"
-        bg={CIRCLE_COLORS[(number - 1) % CIRCLE_COLORS.length]}
-        boxShadow="md"
-        borderRadius="sm"
-      ></Box>
-
-      <Flex flexDirection={"column"} gap={0} width={"fit-content"}>
-        <Text
-          fontSize={"xl"}
-          color="white"
-          fontFamily={"ProRacing"}
-          transformOrigin={"top left"}
-        >
-          {event.name}
-        </Text>
-
-        <Flex
-          flexDirection={{
-            base: "column",
-            md: "row"
-          }}
-          gap={0}
-          width={"fit-content"}
-        >
-          <Text
-            fontSize={"lg"}
-            color="gray.100"
-            fontWeight="bold"
-            fontFamily="Magistral"
-            letterSpacing="0.5px"
-            transformOrigin={"top left"}
-            wordBreak="break-all"
-            whiteSpace="normal"
-            mr={3}
-          >
-            {event.location || "Siebel CS"}
-          </Text>
-
-          <Text
-            fontSize={"lg"}
-            color="gray.400"
-            fontWeight="bold"
-            fontFamily="Magistral"
-            letterSpacing="0.5px"
-            transformOrigin={"top left"}
-            whiteSpace={{
-              md: "nowrap"
-            }}
-          >
-            {moment(event.startTime).format("h:mma")} –{" "}
-            {moment(event.endTime).format("h:mma")}
-          </Text>
-        </Flex>
-      </Flex>
-
-      <Tooltip
-        label={event.eventType
-          .toLowerCase()
-          .replace(/^\w/, (c) => c.toUpperCase())}
-        fontFamily="Magistral"
-        fontSize="lg"
-        fontWeight={600}
-        placement="top"
-        hasArrow
-      >
-        <Flex w="30px" h="30px" justifyContent={"center"} alignItems={"center"}>
-          <Icon
-            as={EVENT_ICONS[event.eventType]}
-            color="yellow.500"
-            boxSize={6}
-          />
-        </Flex>
-      </Tooltip>
-    </Grid>
-  );
+{
+  /* DayEvent component moved to shared library */
 }

--- a/apps/dashboard/src/components/Leaderboard.tsx
+++ b/apps/dashboard/src/components/Leaderboard.tsx
@@ -192,8 +192,8 @@ function LeaderboardScorecard({
     placePostfix = "rd";
   }
 
-  const stagerOffset = i % 2 == 0 ? pos.width * 0.25 : -pos.width * 0.25;
-  const carOffset = stagerOffset + 0.5 * pos.width;
+  const stagerOffset = i % 2 == 0 ? pos.width * 0.3 : -pos.width * 0.3;
+  const carOffset = stagerOffset + 0.6 * pos.width; // Increased offset for better spacing
   const left = pos.x + carOffset;
   const top = pos.y;
 
@@ -203,8 +203,8 @@ function LeaderboardScorecard({
       transform={"translate(0,-50%)"}
       backgroundColor={"#0000008c"}
       width={"max-content"}
-      padding={"0.25rem"}
-      borderRadius={"0.5rem"}
+      padding={"0.5vh"}
+      borderRadius={"1vh"}
       transition={"opacity 0.5s"}
       // Style inlined here to prevent chakra generating a new class every frame
       style={{
@@ -214,25 +214,40 @@ function LeaderboardScorecard({
       }}
     >
       <Flex
-        border={`2px solid ${ICON_COLOR_TO_COLOR[icon]}`}
-        borderRadius={"0.5rem"}
-        padding={"0.75rem"}
+        border={`0.2vh solid ${ICON_COLOR_TO_COLOR[icon]}`}
+        borderRadius={"0.8vh"}
+        padding={"0.5vh"}
+        paddingX="0.9vh"
         alignItems={"center"}
       >
-        <Text marginRight={"0.5rem"}>
+        <Text
+          marginRight={"0.5vh"}
+          fontFamily={"Magistral"}
+          fontWeight={"bold"}
+          letterSpacing={"0.1vh"}
+          fontSize={"1.7vh"}
+        >
           {rank}
           <small>{placePostfix}</small>
         </Text>
-        <Box marginRight={"0.5rem"}>
+        <Box marginRight={"0.5vh"}>
           <Icon
-            width={"3rem"}
-            height={"3rem"}
+            width={"4vh"}
+            height={"4vh"}
             color={ICON_COLOR_TO_COLOR[icon]}
           />
         </Box>
         <Flex flexDirection={"column"}>
-          <Text fontWeight={"bold"}>{displayName}</Text>
-          <Text>{points} PTS</Text>
+          <Text
+            fontWeight={"black"}
+            fontFamily={"Magistral"}
+            fontSize={"1.5vh"}
+          >
+            {displayName}
+          </Text>
+          <Text fontFamily={"Magistral"} fontSize={"1.2vh"} fontWeight="bold">
+            {points} PTS
+          </Text>
         </Flex>
       </Flex>
     </Box>

--- a/apps/dashboard/src/components/RaceClock.tsx
+++ b/apps/dashboard/src/components/RaceClock.tsx
@@ -82,7 +82,7 @@ export function RaceClock() {
       {/* Tenths */}
       <ClockSegment value={clockParts.ms} w="1vh" />
       {/* AM/PM */}
-      <ClockSegment value={clockParts.meridian} w="4vh" />
+      <ClockSegment value={clockParts.meridian} w="3.5vh" />
     </Flex>
   );
 }

--- a/apps/dashboard/src/components/RaceClock.tsx
+++ b/apps/dashboard/src/components/RaceClock.tsx
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 
 function ClockSegment({
   value,
-  w = "0.5em",
+  w = "1vh",
   semicolon = false
 }: {
   value: string;
@@ -15,13 +15,13 @@ function ClockSegment({
     <Text
       as="span"
       fontFamily="SevenSegment"
-      fontSize="3xl"
+      fontSize="2vh"
       letterSpacing="0"
       width={w}
       display="inline-block"
       textAlign="center"
       lineHeight="1"
-      mb={semicolon ? 3 : undefined}
+      mb={semicolon ? ".7vh" : undefined}
       color="red.500"
     >
       {value}
@@ -51,18 +51,18 @@ export function RaceClock() {
   return (
     <Flex
       display={"flex"}
-      gap="0.12em"
+      gap="0.12vh"
       alignItems="center"
       fontFamily="SevenSegment"
       fontWeight="bold"
       bgColor={"rgba(0,0,0,0.2)"}
-      px={3}
-      py={1}
-      borderRadius={"md"}
+      px="1.5vh"
+      py="0.5vh"
+      borderRadius={"0.5vh"}
       borderColor={"gray.600"}
       userSelect="none"
-      mr={3}
-      mt={3}
+      mr="1.5vh"
+      mt="1.5vh"
       sx={{
         backdropFilter: "blur(12px)",
         WebkitBackdropFilter: "blur(12px)"
@@ -71,19 +71,19 @@ export function RaceClock() {
       {/* Hour */}
       <ClockSegment value={clockParts.hours[0]} />
       <ClockSegment value={clockParts.hours[1]} />
-      <ClockSegment value=":" w="0.7em" semicolon />
+      <ClockSegment value=":" w="1vh" semicolon />
       {/* Minute */}
       <ClockSegment value={clockParts.minutes[0]} />
       <ClockSegment value={clockParts.minutes[1]} />
-      <ClockSegment value=":" w="0.7em" semicolon />
+      <ClockSegment value=":" w="1vh" semicolon />
       {/* Second */}
       <ClockSegment value={clockParts.seconds[0]} />
       <ClockSegment value={clockParts.seconds[1]} />
-      <ClockSegment value="." w="0.6em" />
+      <ClockSegment value="." w="1vh" />
       {/* Tenths */}
-      <ClockSegment value={clockParts.ms} w="0.85em" />
+      <ClockSegment value={clockParts.ms} w="1vh" />
       {/* AM/PM */}
-      <ClockSegment value={clockParts.meridian} w="1.8em" />
+      <ClockSegment value={clockParts.meridian} w="4vh" />
     </Flex>
   );
 }

--- a/apps/dashboard/src/components/RaceClock.tsx
+++ b/apps/dashboard/src/components/RaceClock.tsx
@@ -15,7 +15,7 @@ function ClockSegment({
     <Text
       as="span"
       fontFamily="SevenSegment"
-      fontSize="2vh"
+      fontSize="2.5vh"
       letterSpacing="0"
       width={w}
       display="inline-block"
@@ -51,7 +51,7 @@ export function RaceClock() {
   return (
     <Flex
       display={"flex"}
-      gap="0.12vh"
+      gap="0.35vh"
       alignItems="center"
       fontFamily="SevenSegment"
       fontWeight="bold"
@@ -61,7 +61,6 @@ export function RaceClock() {
       borderRadius={"0.5vh"}
       borderColor={"gray.600"}
       userSelect="none"
-      mr="1.5vh"
       mt="1.5vh"
       sx={{
         backdropFilter: "blur(12px)",

--- a/apps/dashboard/src/components/RegisterNow.tsx
+++ b/apps/dashboard/src/components/RegisterNow.tsx
@@ -14,22 +14,27 @@ export const RegisterNow = () => {
       w="100%"
       display="flex"
       flexDir="column"
-      pt={5}
+      pt="2.5vh"
     >
       <Text
-        fontSize="3xl"
+        fontSize="2.5vh"
         fontWeight="bold"
-        mb={4}
+        mb="2vh"
         fontFamily="ProRacingSlant"
         textAlign="center"
       >
         Register Now for Free
       </Text>
-      <Box display="flex" alignItems="center" justifyContent="center" gap={3}>
+      <Box
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+        gap="1.5vh"
+      >
         {/* QR CODE */}
         <Box
-          p={4}
-          borderRadius="lg"
+          p="1vh"
+          borderRadius="1vh"
           bgColor={"rgba(0,0,0,0.2)"}
           display="flex"
           justifyContent="center"
@@ -41,8 +46,8 @@ export const RegisterNow = () => {
         >
           <QRCode
             style={{
-              width: "150px",
-              height: "150px",
+              width: "12vh",
+              height: "12vh",
               background: "transparent"
             }}
             value={REGISTER_URL}
@@ -53,17 +58,17 @@ export const RegisterNow = () => {
 
         {/* BOUNCING ARROW */}
         <MotionBox
-          ml={5}
+          ml="2.5vh"
           initial={{ y: 0 }}
-          animate={{ x: [0, -8, 0] }}
+          animate={{ x: [0, "-1vh", 0] }}
           transition={{ repeat: Infinity, duration: 1.2, ease: "easeInOut" }}
           display="flex"
           alignItems="center"
           justifyContent="center"
           color="yellow.400"
-          fontSize="2xl"
+          fontSize="2.2vh"
         >
-          <ArrowLeftIcon boxSize={9} />
+          <ArrowLeftIcon boxSize="4vh" />
         </MotionBox>
       </Box>
     </Box>

--- a/apps/dashboard/src/components/Sponsors.tsx
+++ b/apps/dashboard/src/components/Sponsors.tsx
@@ -1,71 +1,93 @@
 import { Box, Image, Text } from "@chakra-ui/react";
 import Marquee from "react-fast-marquee";
+import { useEffect, useState } from "react";
+
+const useMarqueeSpeed = () => {
+  const [speed, setSpeed] = useState(60);
+
+  useEffect(() => {
+    const updateSpeed = () => {
+      const vh = window.innerHeight / 100;
+      setSpeed(vh * 5); // Adjust speed relative to viewport height
+    };
+
+    updateSpeed();
+    window.addEventListener("resize", updateSpeed);
+    return () => window.removeEventListener("resize", updateSpeed);
+  }, []);
+
+  return speed;
+};
 
 const SPONSORS: {
   name: string;
   logo: string;
   height?: string;
 }[] = [
-  { name: "Aechelon", logo: "/sponsors/aechelon.png", height: "60px" },
-  { name: "Capital One", logo: "/sponsors/capitalone.png", height: "40px" },
-  { name: "Caterpillar", logo: "/sponsors/caterpillar.svg", height: "25px" },
-  { name: "Cloudflare", logo: "/sponsors/cloudflare.png", height: "40px" },
-  { name: "Everfox", logo: "/sponsors/everfox.svg", height: "45px" },
-  { name: "Hudson River Trading", logo: "/sponsors/hrt.svg", height: "40px" },
-  { name: "Jane Street", logo: "/sponsors/janestreet.png", height: "40px" },
-  { name: "Qualcomm", logo: "/sponsors/qualcomm.png", height: "30px" },
-  { name: "State Farm", logo: "/sponsors/statefarm.png", height: "25px" }
+  { name: "Aechelon", logo: "/sponsors/aechelon.png", height: "6vh" },
+  { name: "Capital One", logo: "/sponsors/capitalone.png", height: "4vh" },
+  { name: "Caterpillar", logo: "/sponsors/caterpillar.svg", height: "2.5vh" },
+  { name: "Cloudflare", logo: "/sponsors/cloudflare.png", height: "4vh" },
+  { name: "Everfox", logo: "/sponsors/everfox.svg", height: "4.5vh" },
+  { name: "Hudson River Trading", logo: "/sponsors/hrt.svg", height: "4vh" },
+  { name: "Jane Street", logo: "/sponsors/janestreet.png", height: "4vh" },
+  { name: "Qualcomm", logo: "/sponsors/qualcomm.png", height: "3vh" },
+  { name: "State Farm", logo: "/sponsors/statefarm.png", height: "2.5vh" }
 ];
 
-export const Sponsors = () => (
-  <Box position="relative" display={"flex"} flexDir={"column"} gap={3}>
-    <Text
-      fontSize="3xl"
-      fontWeight="bold"
-      textAlign="center"
-      fontFamily="ProRacingSlant"
-    >
-      Sponsors
-    </Text>
-    <Box
-      borderRadius="2xl"
-      boxShadow="0 4px 32px rgba(0,0,0,0.10)"
-      bgColor={"rgba(0,0,0,0.2)"}
-      px={1}
-      py={5}
-      sx={{
-        backdropFilter: "blur(12px)",
-        WebkitBackdropFilter: "blur(12px)"
-      }}
-    >
-      <Marquee
-        gradient={false}
-        speed={60}
-        style={{
-          background: "transparent",
-          maskImage:
-            "linear-gradient(to right, transparent 0%, black 12%, black 88%, transparent 100%)",
-          WebkitMaskImage:
-            "linear-gradient(to right, transparent 0%, black 12%, black 88%, transparent 100%)"
+export const Sponsors = () => {
+  const speed = useMarqueeSpeed();
+
+  return (
+    <Box position="relative" display={"flex"} flexDir={"column"} gap="1.5vh">
+      <Text
+        fontSize="2.5vh"
+        fontWeight="bold"
+        textAlign="center"
+        fontFamily="ProRacingSlant"
+      >
+        Sponsors
+      </Text>
+      <Box
+        borderRadius={"1vh"}
+        boxShadow="0 0.4vh 3.2vh rgba(0,0,0,0.10)"
+        bgColor={"rgba(0,0,0,0.2)"}
+        px="0.5vh"
+        py="2.5vh"
+        sx={{
+          backdropFilter: "blur(12px)",
+          WebkitBackdropFilter: "blur(12px)"
         }}
       >
-        {SPONSORS.map((s, i) => (
-          <Box key={i} mx={6} display="flex" alignItems="center">
-            <Image
-              src={s.logo}
-              alt={s.name}
-              h={s.height ?? "30px"}
-              objectFit="contain"
-              mr={2}
-              filter="brightness(0.92)"
-              style={{
-                filter:
-                  "brightness(0.92) drop-shadow(0 0 6px rgba(255,255,255,0.08))"
-              }}
-            />
-          </Box>
-        ))}
-      </Marquee>
+        <Marquee
+          gradient={false}
+          speed={speed}
+          style={{
+            background: "transparent",
+            maskImage:
+              "linear-gradient(to right, transparent 0%, black 12%, black 88%, transparent 100%)",
+            WebkitMaskImage:
+              "linear-gradient(to right, transparent 0%, black 12%, black 88%, transparent 100%)"
+          }}
+        >
+          {SPONSORS.map((s, i) => (
+            <Box key={i} mx="3vh" display="flex" alignItems="center">
+              <Image
+                src={s.logo}
+                alt={s.name}
+                h={s.height ?? "3vh"}
+                objectFit="contain"
+                mr="1vh"
+                filter="brightness(0.92)"
+                style={{
+                  filter:
+                    "brightness(0.92) drop-shadow(0 0 6px rgba(255,255,255,0.08))"
+                }}
+              />
+            </Box>
+          ))}
+        </Marquee>
+      </Box>
     </Box>
-  </Box>
-);
+  );
+};

--- a/apps/dashboard/src/components/Title.tsx
+++ b/apps/dashboard/src/components/Title.tsx
@@ -1,11 +1,4 @@
-import {
-  Box,
-  Flex,
-  HStack,
-  Text,
-  useMediaQuery,
-  VStack
-} from "@chakra-ui/react";
+import { Box, Flex, HStack, Text, VStack } from "@chakra-ui/react";
 import { motion, useAnimation, useInView } from "framer-motion";
 import { useEffect, useRef } from "react";
 import { RaceClock } from "./RaceClock";
@@ -14,8 +7,7 @@ const MotionBox = motion(Box);
 const MotionText = motion(Text);
 
 export default function Title() {
-  const [isSmall] = useMediaQuery("(max-width: 500px)");
-  const sepH = 40;
+  const sepH = 3.5;
 
   const barRef = useRef(null);
   const inView = useInView(barRef, { once: false }); // allow repeated triggers
@@ -26,24 +18,24 @@ export default function Title() {
 
   const animateIn = async () => {
     await barCtrl.start({
-      height: sepH,
+      height: `${sepH}vh`,
       transition: { duration: 0.8, ease: "easeInOut" }
     });
     await Promise.all([
       refCtrl.start({
-        x: isSmall ? -10 : -20,
+        x: "-1.5vw",
         opacity: 1,
         transition: { duration: 0.8, ease: "easeOut" }
       }),
       projCtrl.start({
-        x: isSmall ? 10 : 20,
+        x: "1.5vw",
         opacity: 1,
         transition: { duration: 0.8, ease: "easeOut" }
       })
     ]);
     await dateCtrl.start({
       opacity: 1,
-      y: 0,
+      y: "0vh",
       transition: { duration: 0.6, ease: "easeOut" }
     });
   };
@@ -51,17 +43,17 @@ export default function Title() {
   const animateOut = async () => {
     await dateCtrl.start({
       opacity: 0,
-      y: -20,
+      y: "-1vh",
       transition: { duration: 0.4, ease: "easeIn" }
     });
     await Promise.all([
       refCtrl.start({
-        x: "100%",
+        x: "30vw",
         opacity: 0,
         transition: { duration: 0.7, ease: "easeIn" }
       }),
       projCtrl.start({
-        x: "-100%",
+        x: "-30vw",
         opacity: 0,
         transition: { duration: 0.7, ease: "easeIn" }
       })
@@ -91,7 +83,7 @@ export default function Title() {
       if (timeout) clearInterval(timeout);
     };
     // eslint-disable-next-line
-  }, [inView, isSmall, sepH]);
+  }, [inView, sepH]);
 
   return (
     <Box width={"100%"} textAlign={"center"}>
@@ -101,17 +93,17 @@ export default function Title() {
         justifyContent={"center"}
       >
         <VStack flexDir={"column"} alignItems={"center"} gap={0}>
-          <HStack justify="center" alignItems="center" gap={0} h="80px">
+          <HStack justify="center" alignItems="center" gap={0} h="6vh">
             <Box
               display="flex"
               overflow="hidden"
-              h={`${sepH}px`}
-              w="500px"
+              h={`${sepH}vh`}
+              w="40vw"
               alignItems="center"
               justifyContent="flex-end"
             >
               <MotionText
-                fontSize={"4xl"}
+                fontSize={"2.5vh"}
                 fontFamily="Roboto Slab"
                 fontWeight="600"
                 letterSpacing="0.03em"
@@ -129,7 +121,7 @@ export default function Title() {
               ref={barRef}
               as="span"
               display="inline-block"
-              w={"5px"}
+              w={"0.2vw"}
               bg="white"
               borderRadius="1px"
               height={0}
@@ -140,12 +132,12 @@ export default function Title() {
             <Box
               display="flex"
               overflow="hidden"
-              h={`${sepH}px`}
-              w="500px"
+              h={`${sepH}vh`}
+              w="40vw"
               alignItems="center"
             >
               <MotionText
-                fontSize={"4xl"}
+                fontSize={"2.5vh"}
                 fontFamily="Roboto Slab"
                 fontWeight="600"
                 letterSpacing="0.03em"
@@ -161,11 +153,11 @@ export default function Title() {
           </HStack>
 
           <MotionText
-            fontSize={"2xl"}
+            fontSize={"1.8vh"}
             fontFamily="Magistral"
             color="gray.300"
             fontWeight="600"
-            initial={{ opacity: 0, y: -20 }}
+            initial={{ opacity: 0, y: "-2vh" }}
             animate={dateCtrl}
             transition={{ duration: 0.6, ease: "easeOut" }}
           >

--- a/apps/dashboard/src/constants/colors.ts
+++ b/apps/dashboard/src/constants/colors.ts
@@ -1,26 +1,5 @@
 import { IconColor } from "@rp/shared";
 
-export const DAY_COLORS = [
-  "#56BF59",
-  "#E6930D",
-  "#FFFFFF",
-  "#FFD93F",
-  "#322BB7"
-];
-
-export const CIRCLE_COLORS = [
-  "green.400",
-  "purple.600",
-  "pink.500",
-  "red.500",
-  "orange.500",
-  "teal.400",
-  "cyan.400",
-  "blue.500",
-  "yellow.400",
-  "pink.600"
-];
-
 export const ICON_COLOR_TO_COLOR: Record<IconColor, string> = {
   BLUE: "#0059ff",
   GREEN: "#218d00",

--- a/apps/site/src/components/Home/Schedule/Schedule.tsx
+++ b/apps/site/src/components/Home/Schedule/Schedule.tsx
@@ -1,26 +1,21 @@
 import {
   Box,
   Flex,
-  Grid,
   HStack,
-  Icon,
   Image,
   Spacer,
   Text,
-  Tooltip,
   useToast
 } from "@chakra-ui/react";
-import { api, Event, path } from "@rp/shared";
+import { api, circleColors, DayEvent, Event, path } from "@rp/shared";
 import moment from "moment";
 import { useCallback, useEffect, useState } from "react";
 
-import { CIRCLE_COLORS } from "@/constants/colors";
-import { EVENT_ICONS } from "@/constants/event-icons";
+import { AnimatedHeader } from "../shared/AnimatedHeader";
+import { AudioVisualizer } from "./AudioVisualizer";
 import EventModal from "./EventModal";
 import { RaceTrack } from "./RaceTrack";
 import ScheduleDaySelector from "./ScheduleDaySelector";
-import { AnimatedHeader } from "../shared/AnimatedHeader";
-import { AudioVisualizer } from "./AudioVisualizer";
 
 export default function Schedule() {
   const toast = useToast();
@@ -319,7 +314,6 @@ function DayEventsSection({
             <DayEvent
               key={index}
               number={index + 1}
-              lastIndex={dayEvents.length}
               hoveredIndex={hoveredIndex}
               event={event}
               onHover={onHover}
@@ -387,7 +381,7 @@ function RaceTrackSection({
         >
           <RaceTrack
             dayEvents={dayEvents}
-            colors={CIRCLE_COLORS}
+            colors={circleColors}
             hoveredIndex={hoveredEventIndex}
             onHover={handleHover}
             onClick={handleSelectEvent}
@@ -477,183 +471,6 @@ function RaceTrackSection({
         </Box>
       </Box>
     </Flex>
-  );
-}
-
-function DayEvent({
-  number,
-  hoveredIndex,
-  lastIndex,
-  event,
-  onHover,
-  onClick
-}: {
-  number: number;
-  hoveredIndex: number | null;
-  lastIndex: number;
-  event: Event;
-  onHover: (index: number) => void;
-  onClick: (event: Event) => void;
-}) {
-  // Check if this is Sue's keynote event
-  const isSueKeynote =
-    event.name.toLowerCase().includes("sue") &&
-    event.eventType.toLowerCase() === "speaker";
-  return (
-    <Grid
-      w="100%"
-      px={{
-        base: 3,
-        md: 5
-      }}
-      py={2}
-      templateColumns={{
-        base: "12px 8px 1fr 40px",
-        md: "20px 10px 1fr 40px"
-      }}
-      alignItems="center"
-      bgColor={hoveredIndex === number ? "#333131" : "#242424"}
-      borderTopRadius={{
-        base: number === 1 ? "xl" : "none",
-        md: "none"
-      }}
-      borderBottomRadius={{
-        base: lastIndex === number ? "xl" : "none",
-        md: "none"
-      }}
-      gap={{
-        base: 2,
-        md: 3
-      }}
-      _hover={{
-        bgColor: "#4D4C4C",
-        cursor: "pointer"
-      }}
-      transition={"all 0.2s"}
-      onMouseEnter={() => {
-        onHover(number);
-      }}
-      onMouseLeave={() => {
-        onHover(-1);
-      }}
-      onClick={() => {
-        onClick(event);
-      }}
-    >
-      <Box
-        display="flex"
-        justifyContent={"center"}
-        alignItems={"center"}
-        w={{
-          base: "10px",
-          md: "20px"
-        }}
-        borderRadius="sm"
-      >
-        <Text
-          fontSize={{
-            base: "lg",
-            md: "2xl"
-          }}
-          color="gray.200"
-          fontWeight="thin"
-          textAlign="center"
-          fontFamily="ProRacingSlant"
-          mb={"2px"}
-          mt={"4px"}
-        >
-          {number}
-        </Text>
-      </Box>
-
-      <Box
-        display="flex"
-        justifyContent={"center"}
-        alignItems={"center"}
-        w={{
-          base: "5px",
-          md: "7px"
-        }}
-        h="50px"
-        bg={CIRCLE_COLORS[(number - 1) % CIRCLE_COLORS.length]}
-        boxShadow="md"
-        borderRadius="sm"
-      ></Box>
-
-      <Flex flexDirection={"column"} gap={0}>
-        <Text
-          fontSize={{ base: "xl", md: "lg" }}
-          color="white"
-          fontFamily={"ProRacing"}
-          transformOrigin={"top left"}
-          w="100%"
-          // Keynote speaker text glow
-          textShadow={isSueKeynote ? "0 0 10px rgba(255, 215, 0, 0.8)" : "none"}
-        >
-          {isSueKeynote ? `★ ${event.name}` : event.name}
-        </Text>
-
-        <Flex
-          flexDirection={{
-            base: "column",
-            md: "row"
-          }}
-          gap={0}
-        >
-          <Text
-            fontSize={{ base: "md", md: "md" }}
-            color="gray.100"
-            fontWeight="bold"
-            fontFamily="Magistral"
-            letterSpacing="0.5px"
-            transformOrigin={"top left"}
-            wordBreak="break-all"
-            whiteSpace="normal"
-            mr={3}
-          >
-            {event.location || "Siebel CS"}
-          </Text>
-
-          <Text
-            fontSize={{ base: "md", md: "md" }}
-            color="gray.400"
-            fontWeight="bold"
-            fontFamily="Magistral"
-            letterSpacing="0.5px"
-            transformOrigin={"top left"}
-            whiteSpace={{
-              md: "nowrap"
-            }}
-          >
-            {formatEventRange(event.startTime, event.endTime)}
-          </Text>
-        </Flex>
-      </Flex>
-
-      <Tooltip
-        label={event.eventType
-          .toLowerCase()
-          .replace(/^\w/, (c) => c.toUpperCase())}
-        fontFamily="Magistral"
-        fontSize="lg"
-        fontWeight={600}
-        placement="top"
-        hasArrow
-      >
-        <Flex w="30px" h="30px" justifyContent={"center"} alignItems={"center"}>
-          <Icon
-            as={EVENT_ICONS[event.eventType]}
-            color={isSueKeynote ? "gold" : "yellow.500"}
-            boxSize={6}
-            filter={
-              isSueKeynote
-                ? "drop-shadow(0 0 8px rgba(255, 215, 0, 0.8))"
-                : "none"
-            }
-          />
-        </Flex>
-      </Tooltip>
-    </Grid>
   );
 }
 

--- a/apps/site/src/components/Home/Schedule/ScheduleDaySelector.tsx
+++ b/apps/site/src/components/Home/Schedule/ScheduleDaySelector.tsx
@@ -1,6 +1,5 @@
-import { DAY_COLORS } from "@/constants/colors";
 import { Box, Flex, Text, VStack } from "@chakra-ui/react";
-import { Event } from "@rp/shared";
+import { dayColors, Event } from "@rp/shared";
 import { useMemo } from "react";
 
 import { motion, useInView } from "framer-motion";
@@ -46,7 +45,7 @@ export default function ScheduleDaySelector({
           }}
         >
           <ScheduleDayButton
-            color={DAY_COLORS[index % DAY_COLORS.length]}
+            color={dayColors[index % dayColors.length]}
             date={date}
             selected={selectedDay === date}
             onSelectDay={onSelectDay}

--- a/shared/src/assets/event-circle-colors.ts
+++ b/shared/src/assets/event-circle-colors.ts
@@ -1,12 +1,4 @@
-export const DAY_COLORS = [
-  "#56BF59",
-  "#E6930D",
-  "#FFFFFF",
-  "#FFD93F",
-  "#322BB7"
-];
-
-export const CIRCLE_COLORS = [
+export const circleColors = [
   "green.400",
   "purple.600",
   "pink.500",

--- a/shared/src/assets/event-day-colors.ts
+++ b/shared/src/assets/event-day-colors.ts
@@ -1,0 +1,7 @@
+export const dayColors = [
+  "#56BF59",
+  "#E6930D",
+  "#FFFFFF",
+  "#FFD93F",
+  "#322BB7"
+];

--- a/shared/src/assets/event-icons.ts
+++ b/shared/src/assets/event-icons.ts
@@ -1,0 +1,20 @@
+import { EventType } from "@rp/shared";
+import { IconType } from "react-icons";
+
+import {
+  FaBriefcase,
+  FaCheck,
+  FaHandshake,
+  FaMicrophone,
+  FaStar,
+  FaUtensils
+} from "react-icons/fa";
+
+export const eventIcons: Record<EventType, IconType> = {
+  SPECIAL: FaStar, // star for special events
+  SPEAKER: FaMicrophone, // microphone for speaker sessions
+  CORPORATE: FaBriefcase, // briefcase for corporate events
+  PARTNERS: FaHandshake, // handshake for partners
+  MEALS: FaUtensils, // utensils for meal breaks
+  CHECKIN: FaCheck // checkmark for check-in
+};

--- a/shared/src/components/DayEvent.tsx
+++ b/shared/src/components/DayEvent.tsx
@@ -1,0 +1,265 @@
+import { Box, Flex, Grid, Icon, Text, Tooltip } from "@chakra-ui/react";
+import moment from "moment";
+import { Event } from "../api/types";
+import { circleColors } from "../assets/event-circle-colors";
+import { eventIcons } from "../assets/event-icons";
+
+export type DayEventProps = {
+  number: number;
+  event: Event;
+  selected?: boolean;
+  variant?: "dashboard" | "website";
+  showNumber?: boolean;
+  // Website-specific props
+  hoveredIndex?: number | null;
+  onHover?: (index: number) => void;
+  onClick?: (event: Event) => void;
+};
+
+export default function DayEvent({
+  number,
+  event,
+  selected,
+  variant = "website",
+  showNumber = true,
+  hoveredIndex,
+  onHover,
+  onClick,
+  ...props
+}: DayEventProps) {
+  const isDashboard = variant === "dashboard";
+  const dashboardStyles = {
+    fontSize: {
+      number: "1.5vh",
+      title: "1.8vh",
+      details: "1.4vh",
+      tooltip: "1.8vh"
+    },
+    spacing: {
+      grid: {
+        px: "1.2vh",
+        py: "1.5vh",
+        gap: "0.5vh",
+        templateColumns: "2vh 1vh 1fr 4vh"
+      },
+      icon: {
+        size: "2vh",
+        container: "3vh"
+      }
+    },
+    borderRadius: "0.5vh",
+    lineWidth: "0.4vh"
+  };
+
+  // Website-specific styles
+  const websiteStyles = {
+    fontSize: {
+      number: { base: "1.3rem", md: "1.8rem" },
+      title: { base: "1rem", md: "1.2rem" },
+      details: { base: "0.8rem", md: "0.9rem" },
+      tooltip: { base: "0.9rem", md: "1rem" }
+    },
+    spacing: {
+      grid: {
+        px: {
+          base: 0,
+          md: 4
+        },
+        py: 3,
+        gap: 3,
+        templateColumns: { base: "25px 8px 1fr 40px", md: "40px 8px 1fr 40px" }
+      },
+      icon: {
+        size: 6,
+        container: "30px"
+      },
+      line: {
+        height: "50px"
+      }
+    },
+    borderRadius: "md",
+    lineWidth: "8px"
+  };
+
+  // Check if this is Sue's keynote event
+  const isSueKeynote =
+    event.name.toLowerCase().includes("sue") &&
+    event.eventType.toLowerCase() === "speaker";
+
+  const styles = isDashboard ? dashboardStyles : websiteStyles;
+
+  return (
+    <Grid
+      px={styles.spacing.grid.px}
+      py={styles.spacing.grid.py}
+      templateColumns={styles.spacing.grid.templateColumns}
+      alignItems="right"
+      gap={styles.spacing.grid.gap}
+      backgroundColor={
+        isDashboard
+          ? selected
+            ? "rgba(255,255,255,0.2)"
+            : undefined
+          : hoveredIndex === number
+            ? "#333131"
+            : "#242424"
+      }
+      borderRadius={isDashboard && selected ? styles.borderRadius : undefined}
+      _first={{
+        paddingTop: isDashboard ? "1.5vh" : 3,
+        borderTopRadius: isDashboard
+          ? styles.borderRadius
+          : {
+              base: styles.borderRadius,
+              md: "none"
+            }
+      }}
+      _last={{
+        paddingBottom: isDashboard ? "1.5vh" : 3,
+        borderBottomRadius: isDashboard
+          ? styles.borderRadius
+          : {
+              base: styles.borderRadius,
+              md: "none"
+            }
+      }}
+      _hover={
+        !isDashboard
+          ? {
+              bgColor: "#4D4C4C",
+              cursor: "pointer"
+            }
+          : undefined
+      }
+      transition={"all 0.2s"}
+      onMouseEnter={onHover ? () => onHover(number) : undefined}
+      onMouseLeave={onHover ? () => onHover(-1) : undefined}
+      onClick={onClick ? () => onClick(event) : undefined}
+      sx={{
+        backdropFilter: "blur(3px)",
+        WebkitBackdropFilter: "blur(3px)"
+      }}
+      {...props}
+    >
+      {showNumber && (
+        <Box
+          display="flex"
+          justifyContent={"center"}
+          alignItems={"center"}
+          w={isDashboard ? "1vh" : "40px"}
+          borderRadius={isDashboard ? "0.2vh" : "md"}
+        >
+          <Text
+            fontSize={styles.fontSize.number}
+            color="gray.200"
+            fontWeight="thin"
+            textAlign="center"
+            fontFamily="ProRacingSlant"
+            mb={isDashboard ? "0.2vh" : 1}
+            mt={isDashboard ? "0.4vh" : 1}
+          >
+            {number}
+          </Text>
+        </Box>
+      )}
+
+      <Box
+        display="flex"
+        justifyContent={"center"}
+        alignItems={"center"}
+        w={
+          isDashboard ? styles.lineWidth : { base: "4px", md: styles.lineWidth }
+        }
+        h={isDashboard ? "100%" : { base: "50px", md: "100%" }}
+        bg={circleColors[(number - 1) % circleColors.length]}
+        boxShadow="md"
+        mx={isDashboard ? 0 : { base: "auto", md: 0 }}
+        my={
+          isDashboard
+            ? 0
+            : {
+                base: "auto",
+                md: 0
+              }
+        }
+        borderRadius={isDashboard ? "0.2vh" : "sm"}
+      />
+
+      <Flex flexDirection={"column"} gap={0} width={"fit-content"}>
+        <Text
+          fontSize={styles.fontSize.title}
+          color="white"
+          fontFamily={"ProRacing"}
+          transformOrigin={"top left"}
+          textShadow={isSueKeynote ? "0 0 10px rgba(255, 215, 0, 0.8)" : "none"}
+        >
+          {isSueKeynote ? `★ ${event.name}` : event.name}
+        </Text>
+
+        <Flex
+          flexDirection={isDashboard ? "row" : { base: "column", md: "row" }}
+          gap={0}
+          width={"fit-content"}
+        >
+          <Text
+            fontSize={styles.fontSize.details}
+            color="gray.100"
+            fontWeight="bold"
+            fontFamily="Magistral"
+            letterSpacing={isDashboard ? "0.05vh" : "0.5px"}
+            transformOrigin={"top left"}
+            wordBreak="break-all"
+            whiteSpace="normal"
+            mr={isDashboard ? "1.5vh" : { base: 0, md: 3 }}
+          >
+            {event.location || "Siebel CS"}
+          </Text>
+
+          <Text
+            fontSize={styles.fontSize.details}
+            color="gray.400"
+            fontWeight="bold"
+            fontFamily="Magistral"
+            letterSpacing={isDashboard ? "0.05vh" : "0.5px"}
+            transformOrigin={"top left"}
+            whiteSpace={
+              isDashboard ? "nowrap" : { base: "normal", md: "nowrap" }
+            }
+          >
+            {moment(event.startTime).format("h:mma")} –{" "}
+            {moment(event.endTime).format("h:mma")}
+          </Text>
+        </Flex>
+      </Flex>
+
+      <Tooltip
+        label={event.eventType
+          .toLowerCase()
+          .replace(/^\w/, (c) => c.toUpperCase())}
+        fontFamily="Magistral"
+        fontSize={styles.fontSize.tooltip}
+        fontWeight={600}
+        placement="top"
+        hasArrow
+      >
+        <Flex
+          w={styles.spacing.icon.container}
+          h={styles.spacing.icon.container}
+          justifyContent={"center"}
+          alignItems={"center"}
+        >
+          <Icon
+            as={eventIcons[event.eventType]}
+            color={isSueKeynote ? "gold" : "yellow.500"}
+            boxSize={styles.spacing.icon.size}
+            filter={
+              isSueKeynote
+                ? "drop-shadow(0 0 8px rgba(255, 215, 0, 0.8))"
+                : "none"
+            }
+          />
+        </Flex>
+      </Tooltip>
+    </Grid>
+  );
+}

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,5 +1,6 @@
 export { default as Banner } from "./components/Banner";
 export { default as AnimatedCounter } from "./components/AnimatedCounter";
+export { default as DayEvent } from "./components/DayEvent";
 export * from "./api/types";
 export { default as usePolling } from "./hooks/polling";
 export { default as useFormAutosave } from "./hooks/form-autosave";
@@ -22,5 +23,8 @@ export { minors } from "./assets/minors";
 export { graduationDates } from "./assets/graduation-dates";
 export { educationLevels } from "./assets/education-levels";
 export { employmentOpportunities } from "./assets/employment-opportunities";
+export { eventIcons } from "./assets/event-icons";
+export { circleColors } from "./assets/event-circle-colors";
+export { dayColors } from "./assets/event-day-colors";
 export { default as api } from "./api/api";
 export * from "./util";


### PR DESCRIPTION
- Used `vh`-based height on the dashboard to ensure it scales well to the Siebel TVs. Now the dashboard should look good on any display, unaffected by zoom level, as long as it has a roughly 16:9 aspect ratio

500% zoom: (Track gets blurred around 300% zoom, but I don't think we'll deal with this edge case since the Siebel TVs in aggregate have a very high resolution)
<img width="2425" height="1304" alt="Screenshot 2025-09-14 at 2 37 02 PM" src="https://github.com/user-attachments/assets/760da746-0c0c-4f30-9e4f-0c4ae71348a5" />

25% zoom: (More likely to represent what could happen on Siebel TVs)
<img width="2415" height="1305" alt="Screenshot 2025-09-14 at 2 37 17 PM" src="https://github.com/user-attachments/assets/adac3cfa-5395-4fcc-9095-faf0437a7a0c" />

- Changed font on the leaderboard to Magistral for consistency with the rest of the site
- Refactored DayEvent into `@rp/shared`, and added control for separate website and dashboard styles. I rigorously tested for regressions on the main site and dashboard, and everything looks good to me now, but I'd appreciate testing to ensure there are no regressions.