### PR TITLE
Fix dash for siebel tvs

### DIFF
--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -48,6 +48,7 @@ function App() {
           alignItems={"center"}
           width={"100%"}
           minH="100vh"
+          boxSizing="border-box"
           padding={"2vh"}
           paddingTop="0.5vh"
           zIndex={2}

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -74,7 +74,7 @@ function App() {
             <Flex width={"50%"} marginRight={"1vh"} alignItems={"flex-end"}>
               <RegisterNow />
             </Flex>
-            <Flex width={"50%"} flexDir={"column"} gap={"1.5vh"}>
+            <Flex width={"50%"} flexDir={"column"}>
               <Events />
               <Sponsors />
             </Flex>

--- a/apps/dashboard/src/components/Events.tsx
+++ b/apps/dashboard/src/components/Events.tsx
@@ -89,7 +89,7 @@ export default function Events() {
   }, [events, date]);
 
   return (
-    <Box float={"right"} width={"100%"}>
+    <Box float={"right"} width={"100%"} mb={"1.5vh"}>
       <Text
         w="100%"
         fontSize={"3vh"}
@@ -120,7 +120,6 @@ export default function Events() {
             <Box
               overflowY="auto"
               height={"100%"}
-              gap={"1vh"}
               display="flex"
               flexDirection={"column"}
               px={"1vh"}

--- a/apps/dashboard/src/components/RaceClock.tsx
+++ b/apps/dashboard/src/components/RaceClock.tsx
@@ -12,10 +12,12 @@ dayjs.tz.setDefault("America/Chicago");
 
 function ClockSegment({
   value,
+  mr,
   w = "1.5vh",
   semicolon = false
 }: {
   value: string;
+  mr: string;
   w?: string;
   semicolon?: boolean;
 }) {
@@ -29,6 +31,7 @@ function ClockSegment({
       display="inline-block"
       textAlign="center"
       lineHeight="1"
+      mr={mr}
       mb={semicolon ? ".7vh" : undefined}
       color="red.500"
     >
@@ -58,7 +61,6 @@ export function RaceClock() {
   return (
     <Flex
       display={"flex"}
-      gap="0.35vh"
       alignItems="center"
       fontFamily="SevenSegment"
       fontWeight="bold"
@@ -75,21 +77,21 @@ export function RaceClock() {
       }}
     >
       {/* Hour */}
-      <ClockSegment value={clockParts.hours[0]} />
-      <ClockSegment value={clockParts.hours[1]} />
-      <ClockSegment value=":" w="1vh" semicolon />
+      <ClockSegment mr={"0.35vh"} value={clockParts.hours[0]} />
+      <ClockSegment mr={"0.35vh"} value={clockParts.hours[1]} />
+      <ClockSegment mr={"0.35vh"} value=":" w="1vh" semicolon />
       {/* Minute */}
-      <ClockSegment value={clockParts.minutes[0]} />
-      <ClockSegment value={clockParts.minutes[1]} />
-      <ClockSegment value=":" w="1vh" semicolon />
+      <ClockSegment mr={"0.35vh"} value={clockParts.minutes[0]} />
+      <ClockSegment mr={"0.35vh"} value={clockParts.minutes[1]} />
+      <ClockSegment mr={"0.35vh"} value=":" w="1vh" semicolon />
       {/* Second */}
-      <ClockSegment value={clockParts.seconds[0]} />
-      <ClockSegment value={clockParts.seconds[1]} />
-      <ClockSegment value="." w="1vh" />
+      <ClockSegment mr={"0.35vh"} value={clockParts.seconds[0]} />
+      <ClockSegment mr={"0.35vh"} value={clockParts.seconds[1]} />
+      <ClockSegment mr={"0.35vh"} value="." w="1vh" />
       {/* Tenths */}
-      <ClockSegment value={clockParts.ms} w="1vh" />
+      <ClockSegment mr={"0.35vh"} value={clockParts.ms} />
       {/* AM/PM */}
-      <ClockSegment value={clockParts.meridian} w="6vh" />
+      <ClockSegment mr={"0"} value={clockParts.meridian} w="4vh" />
     </Flex>
   );
 }

--- a/apps/dashboard/src/components/RaceClock.tsx
+++ b/apps/dashboard/src/components/RaceClock.tsx
@@ -43,7 +43,7 @@ function ClockSegment({
 function useClockParts() {
   const time = useTime(100);
   return useMemo(() => {
-    const now = dayjs(time).tz();
+    const now = dayjs(time).tz("America/Chicago");
     const hours = now.format("h");
     return {
       hours: hours.padStart(2, "0"),

--- a/apps/dashboard/src/components/RegisterNow.tsx
+++ b/apps/dashboard/src/components/RegisterNow.tsx
@@ -25,12 +25,7 @@ export const RegisterNow = () => {
       >
         Register Now for Free
       </Text>
-      <Box
-        display="flex"
-        alignItems="center"
-        justifyContent="center"
-        gap="1.5vh"
-      >
+      <Box display="flex" alignItems="center" justifyContent="center">
         {/* QR CODE */}
         <Box
           p="1vh"
@@ -43,6 +38,7 @@ export const RegisterNow = () => {
             backdropFilter: "blur(12px)",
             WebkitBackdropFilter: "blur(12px)"
           }}
+          marginRight={"1.5vh"}
         >
           <QRCode
             style={{

--- a/apps/dashboard/src/components/Sponsors.tsx
+++ b/apps/dashboard/src/components/Sponsors.tsx
@@ -42,12 +42,13 @@ export const Sponsors = () => {
   const speed = useMarqueeSpeed();
 
   return (
-    <Box position="relative" display={"flex"} flexDir={"column"} gap="1.5vh">
+    <Box position="relative" display={"flex"} flexDir={"column"}>
       <Text
         fontSize="3vh"
         fontWeight="bold"
         textAlign="center"
         fontFamily="ProRacingSlant"
+        marginBottom="1.5vh"
       >
         Sponsors
       </Text>

--- a/apps/dashboard/src/index.css
+++ b/apps/dashboard/src/index.css
@@ -3,6 +3,12 @@
   background-color: #000000;
 }
 
+/* Required for abnormal style sheets (QtWebEngine looking at you) */
+* {
+  margin: 0;
+  padding: 0;
+}
+
 .condensed {
   font-stretch: condensed;
 }

--- a/shared/src/components/DayEvent.tsx
+++ b/shared/src/components/DayEvent.tsx
@@ -95,6 +95,7 @@ export default function DayEvent({
       templateColumns={styles.spacing.grid.templateColumns}
       alignItems="right"
       gap={styles.spacing.grid.gap}
+      mb={isDashboard ? "1vh" : undefined}
       backgroundColor={
         isDashboard
           ? selected
@@ -121,7 +122,8 @@ export default function DayEvent({
           : {
               base: styles.borderRadius,
               md: "none"
-            }
+            },
+        mb: isDashboard ? "0" : undefined
       }}
       _hover={
         !isDashboard


### PR DESCRIPTION
First, some background.

Siebel's main giant screen has the following specs: `1920x1080 (dpr 1) - Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) KorbytPlayer/3.21.2 Chrome/114.0.5735.289 Electron/25.8.4 Safari/537.36 - Win32`
The tvs dotted around have the following specs: `1920x1080 (dpr 1) - BrightSign/9.0.211 (XD235) Mozilla/5.0 (X11; Linux aarch64) AppleWebKit/537.36 (KHTML, like Gecko) QtWebEngine/5.15.2 Chrome/87.0.4280.144 Safari/537.36 - Linux aarch64`

Importantly, our dashboard renders fine on the giant screen but has issues on the tvs. This is because the tvs use (a very old, probably because they don't want to pay for a new license) QtWebEngine 5.15.2, which does not render certain things properly.

To address this, I manually installed QtWebEngine and nearly lost my mind.
<details><summary>Open for details</summary>
Installed from https://account.qt.io/s/archived-versions (Qt > 5.15.2 > Linux), needed to create temp account to trial.

Created a simple project:

`rp.pro`:
```pro
QT       += core gui webenginewidgets webengine

greaterThan(QT_MAJOR_VERSION, 4): QT += widgets

CONFIG += c++11

# You can make your code fail to compile if it uses deprecated APIs.
# In order to do so, uncomment the following line.
#DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0

SOURCES += \
    main.cpp \
    mainwindow.cpp

HEADERS += \
    mainwindow.h

FORMS += \
    mainwindow.ui

# Default rules for deployment.
qnx: target.path = /tmp/$${TARGET}/bin
else: unix:!android: target.path = /opt/$${TARGET}/bin
!isEmpty(target.path): INSTALLS += target
```

`mainwindow.h`:
```h
#ifndef MAINWINDOW_H
#define MAINWINDOW_H

#include <QMainWindow>
#include <QLabel>
#include <QWebEngineView>
#include <QCoreApplication>
#include <QUrl>

QT_BEGIN_NAMESPACE
namespace Ui { class MainWindow; }
QT_END_NAMESPACE

class MainWindow : public QMainWindow
{
    Q_OBJECT

public:
    MainWindow(QWidget *parent = nullptr);
    ~MainWindow();

private:
    Ui::MainWindow *ui;
    QWebEngineView *webView;
    QLabel *label;
};
#endif // MAINWINDOW_H
```

`mainwindow.cpp`:
```cpp
#include "mainwindow.h"
#include "ui_mainwindow.h"

MainWindow::MainWindow(QWidget *parent)
    : QMainWindow(parent)
    , ui(new Ui::MainWindow)
{
    ui->setupUi(this);

    webView = new QWebEngineView(this);
    setCentralWidget(webView);
    webView->resize(1920, 1080);
    webView->setUrl(QUrl("http://localhost:3006"));

}

MainWindow::~MainWindow()
{
    delete ui;
}
```

`main.cpp`:
```cpp
#include "mainwindow.h"

#include <QApplication>
#include <QtWebEngine>
#include <QWebEngineSettings>

int main(int argc, char *argv[])
{
    QCoreApplication::setAttribute(Qt::AA_UseSoftwareOpenGL);
    qputenv("QTWEBENGINE_DISABLE_SANDBOX", "1");
    qputenv("QTWEBENGINE_REMOTE_DEBUGGING", "9222");
    QApplication a(argc, argv);
    MainWindow w;
    w.resize(800, 600);
    w.show();
    return a.exec();
}
```

*Importantly, needed to disable the sandbox to get anything to render. Enabling remote debugging allowed me to use the oldest chrome console I've ever seen (you have to double click to open elements, crazy)*

Finally, I was able to reproduce what was going on which would have taken forever otherwise.
</details>

This pr addresses the issues I found by:
- Setting margin and padding to 0 by deafult - QtWebEngine applies a giant default padding to text elements
- Aligning our home page - while most modern browsers ignore padding that goes over bounds, QtWebEngine does not. `box-sizing: border-box` fixes that
- Finally: flex gap is a newer feature. Qt does not support flex gap, so I converted all uses into margins. At least grid gap is supported...

Also, I added an explicit timezone but I have a suspicion that the tv's actual time is just off, so we'll see.

Before:
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/9049a79f-ad0b-407e-8989-3acd25568e30" />

*Notice the scrollbars, which explains why everything seemed "zoomed in"*

Now:
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/aa2e298c-e12d-4288-a884-8dec1d80bb43" />
